### PR TITLE
Increase disk space from 30G to 100G

### DIFF
--- a/infra/jenkins-build.yml
+++ b/infra/jenkins-build.yml
@@ -60,7 +60,7 @@
         volumes:
           - device_name: /dev/sda1
             volume_type: gp2
-            volume_size: 30
+            volume_size: 100
       register: govwifi_jenkins_master
 
     - name: Create Jenkins ELB


### PR DESCRIPTION
Due to the way docker uses disk space, we are forced to increase this.
Doesn't seem to be any better way to do this yet.

https://forums.docker.com/t/some-way-to-clean-up-identify-contents-of-var-lib-docker-overlay/30604