### PR TITLE
Add license description to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ Now run:
 ```
 make configure-infra
 ```
+
+## Licence
+
+This codebase is released under [the MIT License][mit].
+
+[mit]: LICENSE


### PR DESCRIPTION
Following GDS standard to add a link to the licence in the readme